### PR TITLE
make cluster-internal non-tls setup work, with proper token authentication

### DIFF
--- a/contrib/helm-charts/portus/templates/nginx-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/nginx-configmap.yaml
@@ -87,7 +87,7 @@ data:
         # http://blog.ivanristic.com/2013/08/configuring-apache-nginx-and-openssl-for-forward-secrecy.html
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
         {{- else }}
-        listen {{ .Values.nginx.service.port }} http2;
+        listen {{ .Values.nginx.service.port }};
         {{- end }}
 
         ##

--- a/contrib/helm-charts/portus/templates/portus-deployment.yaml
+++ b/contrib/helm-charts/portus/templates/portus-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: "portus"
           image: "{{ .Values.portus.image.repository }}:{{ .Values.portus.image.tag }}"
           imagePullPolicy: {{ .Values.portus.image.pullPolicy }}
-          {{- if eq false .Values.portus.tls.enabled }}
+          {{- if not (.Values.portus.tls.key) }}
           command: ["/bin/bash"]
           args: ["-c", "openssl genrsa -out /secrets/portus.key 3072;/init"]
           {{- end }}
@@ -173,7 +173,7 @@ spec:
             - name: secrets
               mountPath: /secrets
       volumes:
-        {{- if .Values.portus.tls.enabled }}
+        {{- if or (.Values.portus.tls.enabled) (.Values.portus.tokenauth.enabled) }}
         - name: secrets
           secret:
             secretName: {{ template "portus.fullname" . }}

--- a/contrib/helm-charts/portus/templates/portus-secret.yaml
+++ b/contrib/helm-charts/portus/templates/portus-secret.yaml
@@ -29,7 +29,7 @@ data:
   PORTUS_PRODUCTION_PASSWORD: {{ .Values.portus.productionPassword | b64enc | quote }}
   {{- end }}
 
-  {{- if .Values.portus.tls.enabled }}
+  {{- if or (.Values.portus.tls.enabled) (.Values.portus.tokenauth.enabled) }}
   key: {{ .Values.portus.tls.key | b64enc | quote }}
   cert: {{ .Values.portus.tls.cert | b64enc | quote }}
   {{- end }}

--- a/contrib/helm-charts/portus/templates/registry-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/registry-configmap.yaml
@@ -23,9 +23,9 @@ data:
   REGISTRY_NOTIFICATIONS_ENDPOINTS: >
     - name: nginx
       {{- if .Values.portus.tls.enabled }}
-      url: https://{{ template "nginx.fullname" . }}/v2/webhooks/events
+      url: https://{{ template "nginx.fullname" . }}:{{.Values.nginx.service.port}}/v2/webhooks/events
       {{- else }}
-      url: http://{{ template "nginx.fullname" . }}/v2/webhooks/events
+      url: http://{{ template "nginx.fullname" . }}:{{.Values.nginx.service.port}}/v2/webhooks/events
       {{- end }}
       timeout: 2000ms
       threshold: 5

--- a/contrib/helm-charts/portus/templates/registry-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/registry-configmap.yaml
@@ -8,13 +8,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- if .Values.portus.tls.enabled }}
+  {{- if or (.Values.portus.tls.enabled) (.Values.portus.tokenauth.enabled) }}
   REGISTRY_AUTH_TOKEN_REALM: {{ printf "https://%s:%d/v2/token" (.Values.nginx.host | default (printf "%s" (include "nginx.fullname" .))) (int .Values.nginx.service.port) | quote }}
   REGISTRY_AUTH_TOKEN_SERVICE: {{ printf "%s:%s" (include "registry.fullname" .) .Values.registry.service.port | quote }}
   REGISTRY_AUTH_TOKEN_ISSUER: {{ template "portus.fullname" . }}
+  REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: "/certificates/portus.crt"
+  {{- if .Values.portus.tls.enabled }}
   REGISTRY_HTTP_TLS_KEY: "/certificates/portus.key"
   REGISTRY_HTTP_TLS_CERTIFICATE: "/certificates/portus.crt"
-  REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: "/certificates/portus.crt"
+  {{- end }}
   {{- else }}
   REGISTRY_AUTH_SILLY_REALM: {{ printf "http://%s:%d/v2/token" (.Values.nginx.host | default (printf "%s" (include "nginx.fullname" .))) (int (.Values.registry.service.nodePort | default .Values.nginx.service.port)) | quote }}
   REGISTRY_AUTH_SILLY_SERVICE: {{ printf "%s:%s" (include "registry.fullname" .) .Values.registry.service.port | quote }}

--- a/contrib/helm-charts/portus/templates/registry-deployment.yaml
+++ b/contrib/helm-charts/portus/templates/registry-deployment.yaml
@@ -33,12 +33,13 @@ spec:
             - containerPort: {{ .Values.registry.service.port }}
             - containerPort: {{ .Values.registry.service.debugPort }}
           env:
-            {{- if .Values.portus.tls.enabled }}
-            - name: REGISTRY_AUTH_TOKEN_REALM
+            {{- if or (.Values.portus.tls.enabled) (.Values.portus.tokenauth.enabled) }}
+            - name: REALM_HOST
               valueFrom:
-                configMapKeyRef:
-                  name: {{ template "registry.fullname" . }}
-                  key: REGISTRY_AUTH_TOKEN_REALM
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: REGISTRY_AUTH_TOKEN_REALM
+              value: {{ printf "http://$(REALM_HOST):%d/v2/token" (int .Values.nginx.service.port) | quote }}
             - name: REGISTRY_AUTH_TOKEN_SERVICE
               valueFrom:
                 configMapKeyRef:
@@ -49,6 +50,12 @@ spec:
                 configMapKeyRef:
                   name: {{ template "registry.fullname" . }}
                   key: REGISTRY_AUTH_TOKEN_ISSUER
+            - name: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
+            {{- if .Values.portus.tls.enabled }}
             - name: REGISTRY_HTTP_TLS_KEY
               valueFrom:
                 configMapKeyRef:
@@ -59,11 +66,7 @@ spec:
                 configMapKeyRef:
                   name: {{ template "registry.fullname" . }}
                   key: REGISTRY_HTTP_TLS_CERTIFICATE
-            - name: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ template "registry.fullname" . }}
-                  key: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
+            {{- end }}
             {{- else }}
             - name: REALM_HOST
               valueFrom:
@@ -85,7 +88,7 @@ spec:
           resources:
 {{ toYaml .Values.registry.resources | indent 12 }}
           volumeMounts:
-            {{- if .Values.portus.tls.enabled }}
+            {{- if or (.Values.portus.tls.enabled) (.Values.portus.tokenauth.enabled) }}
             - name: certvol
               mountPath: /certificates
             {{- end }}
@@ -95,7 +98,7 @@ spec:
             - name: storage
               mountPath: {{ .Values.registry.mountPath }}
       volumes:
-        {{- if .Values.portus.tls.enabled }}
+        {{- if or (.Values.portus.tls.enabled) (.Values.portus.tokenauth.enabled) }}
         - name: certvol
           secret:
             secretName: {{ template "portus.fullname" . }}

--- a/contrib/helm-charts/portus/templates/registry-deployment.yaml
+++ b/contrib/helm-charts/portus/templates/registry-deployment.yaml
@@ -65,11 +65,12 @@ spec:
                   name: {{ template "registry.fullname" . }}
                   key: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
             {{- else }}
-            - name: REGISTRY_AUTH_SILLY_REALM
+            - name: REALM_HOST
               valueFrom:
-                configMapKeyRef:
-                  name: {{ template "registry.fullname" . }}
-                  key: REGISTRY_AUTH_SILLY_REALM
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: REGISTRY_AUTH_SILLY_REALM
+              value: {{ printf "http://$(REALM_HOST):%d/v2/token" (int .Values.nginx.service.port) | quote }}
             - name: REGISTRY_AUTH_SILLY_SERVICE
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
1. removed http2 - we use https://github.com/teamhephy/registry-proxy to get around the "insecure registry" stuff (registries running on localhost don't need TLS), and somehow nothing works when listening as http2

2. we need to set REGISTRY_AUTH_TOKEN_REALM to the actual node IP since the docker running on the nodes can't resolve the k8s DNS name

3. normally, this helm chart uses the same certificate for HTTPS (to the outside world) and for token authentication (only between the actual registry and portus). If you don't give a cert+key it would switch off authentication for the registry (that is, switch to "silly" authentication, which lets everyone through).

    However, token auth itself actually also works with self-signed certs. So this splits it up into `portus.tls.enabled` and `portus.tokenauth.enabled`. Now we can have proper authentication for the registry without needing to setup TLS.